### PR TITLE
Update laravel/installer to ^4.0 since Lambo now targets Larav…

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": "^7.2.5",
-        "laravel/installer": "^3.0.1",
+        "laravel/installer": "^4.0",
         "ext-json": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Update laravel/installer dependency to ^4.0 since Lambo now targets Laravel 8+

Fixes: #131

Tested by adding the following to `~/.composer/composer.json`

```json
"repositories": [
    {
        "type": "vcs",
        "url": "https://github.com/jonsugar/lambo"
    }
]
```